### PR TITLE
Add Python linter GitHub Action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,11 @@ jobs:
       - run: flake8 --config=.flake8 ${{ env.PYTHON_LINT_PATHS }}
       - run: flake8 --config=.flake8.ag ${{ env.AUTOGRAPH_LINT_PATHS }}
     needs: black
+  cpp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: python ./tools/lint.py . --nproc=5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,6 @@ env:
   PYTHON_LINT_PATHS: "./dali ./docs ./tools ./dali_tf_plugin ./qa"
   AUTOGRAPH_LINT_PATHS: "./dali/python/nvidia/dali/_autograph ./dali/test/python/autograph/"
 
-
 jobs:
   python:
     runs-on: ubuntu-latest
@@ -19,7 +18,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install  flake8 "black[jupyter]"==23.11.0
-      - run: black --check --verbose ${{ env.PYTHON_LINT_PATHS }}  ${{ env.AUTOGRAPH_LINT_PATHS }}
+      - run: black --check --verbose ${{ env.PYTHON_LINT_PATHS }} ${{ env.AUTOGRAPH_LINT_PATHS }}
       - run: flake8 --config=.flake8 ${{ env.PYTHON_LINT_PATHS }}
       - run: flake8 --config=.flake8.ag ${{ env.AUTOGRAPH_LINT_PATHS }}
   cpp:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@stable
+      - uses: actions/setup-python@v4
         with:
-          options: "--check --verbose"
-          src: "${{ env.PYTHON_LINT_PATHS }}  ${{ env.AUTOGRAPH_LINT_PATHS }}"
-          jupyter: true
-          version: "23.11.0"
+          python-version: '3.10'
+      - run: pip install "black[jupyter]"==23.11.0
+      - run: black --check --verbose ${{ env.PYTHON_LINT_PATHS }}  ${{ env.AUTOGRAPH_LINT_PATHS }}
   flake8:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+# TODO(klecki): Deduplicate this list of directories with `lint.cmake` file
+env:
+  PYTHON_LINT_PATHS: "./dali ./docs ./tools ./dali_tf_plugin ./qa"
+  AUTOGRAPH_LINT_PATHS: "./dali/python/nvidia/dali/_autograph ./dali/test/python/autograph/"
+
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: "${{ env.PYTHON_LINT_PATHS }}  ${{ env.AUTOGRAPH_LINT_PATHS }}"
+          jupyter: true
+          version: "23.11.0"
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install flake8
+      - run: flake8 --config=.flake8 ${{ env.PYTHON_LINT_PATHS }}
+      - run: flake8 --config=.flake8.ag ${{ env.AUTOGRAPH_LINT_PATHS }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,26 +11,17 @@ env:
 
 
 jobs:
-  black:
+  python:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: pip install "black[jupyter]"==23.11.0
+      - run: pip install  flake8 "black[jupyter]"==23.11.0
       - run: black --check --verbose ${{ env.PYTHON_LINT_PATHS }}  ${{ env.AUTOGRAPH_LINT_PATHS }}
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - run: pip install flake8
       - run: flake8 --config=.flake8 ${{ env.PYTHON_LINT_PATHS }}
       - run: flake8 --config=.flake8.ag ${{ env.AUTOGRAPH_LINT_PATHS }}
-    needs: black
   cpp:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,4 @@ jobs:
       - run: pip install flake8
       - run: flake8 --config=.flake8 ${{ env.PYTHON_LINT_PATHS }}
       - run: flake8 --config=.flake8.ag ${{ env.AUTOGRAPH_LINT_PATHS }}
+    needs: black


### PR DESCRIPTION
Use psf/black action with DALI-compatible configuration. Add custom action that installs and runs flake8.

There is dependency added between those actions, so the flake8 linter is only checked when the black formatting is correct.